### PR TITLE
Add support for providing sort ordering in the tooltip

### DIFF
--- a/panel.go
+++ b/panel.go
@@ -122,6 +122,7 @@ type (
 		Shared       bool   `json:"shared"`
 		ValueType    string `json:"value_type"`
 		MsResolution bool   `json:"msResolution,omitempty"` // was added in Grafana 3.x
+		Sort         uint   `json:"sort,omitempty"`
 	}
 	TablePanel struct {
 		Columns []column `json:"columns"`


### PR DESCRIPTION
It would be nice in some instances to be able to sort the data in the tooltip to make it easier to find outliers when there are a lot of series in a graph.